### PR TITLE
Remove singleton shutdown hook on `RythmEngine`

### DIFF
--- a/src/main/java/org/rythmengine/RythmEngine.java
+++ b/src/main/java/org/rythmengine/RythmEngine.java
@@ -687,36 +687,12 @@ public class RythmEngine implements IEventDispatcher {
             resourceManager().scan();
         }
 
-        ShutdownService service = getShutdownService(conf().gae());
-        service.setShutdown(new Runnable() {
-            @Override
-            public void run() {
-                RythmEngine.this.shutdown();
-            }
-        });
         if (conf().gae()) {
             logger.warn("Rythm engine : GAE in cloud enabled");
         }
         logger.debug("Rythm-%s started in %s mode", version, mode());
     }
 
-
-    public static ShutdownService getShutdownService(boolean isGaeAvailable) {
-        if (!isGaeAvailable) {
-            return DefaultShutdownService.INSTANCE;
-        }
-
-        try {
-            String classname = "org.rythmengine.GaeShutdownService";
-            Class clazz = Class.forName(classname);
-            Object[] oa = clazz.getEnumConstants();
-            ShutdownService result = (ShutdownService) oa[0];
-            return result;
-        } catch (Throwable t) {
-            // Nothing to do
-        }
-        return DefaultShutdownService.INSTANCE;
-    }
     /* -----------------------------------------------------------------------------
       Registrations
     -------------------------------------------------------------------------------*/


### PR DESCRIPTION
This fixes #296.

Best practise is that it is the responsilibilty of the
instantiator/starting to destruct/shutdown an object. The library
doesn't know when a user is done with the `RythmEngine`.

Note that it is totally fine that `Rythm` instance has a shutdown hook
as it is singleton.