### PR TITLE
 Resources should be closed

### DIFF
--- a/src/main/java/org/rythmengine/internal/compiler/TemplateClassCache.java
+++ b/src/main/java/org/rythmengine/internal/compiler/TemplateClassCache.java
@@ -83,10 +83,11 @@ public class TemplateClassCache {
         if (!readEnabled()) {
             return;
         }
+        InputStream is = null;
         try {
             File f = getCacheFile(tc);
             if (!f.exists() || !f.canRead()) return;
-            InputStream is = new BufferedInputStream(new FileInputStream(f));
+            is = new BufferedInputStream(new FileInputStream(f));
 
             // --- check hash
             int offset = 0;
@@ -143,9 +144,15 @@ public class TemplateClassCache {
             is.read(byteCode);
             tc.loadCachedByteCode(byteCode);
 
-            is.close();
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }finally {
+            if(is != null)
+                try {
+                    is.close();
+                } catch (IOException e) {
+                    logger.error(e.getMessage(), e);
+                }
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “ Resources should be closed”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.