### PR TITLE
 "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/src/main/java/org/rythmengine/RythmEngine.java
+++ b/src/main/java/org/rythmengine/RythmEngine.java
@@ -1987,10 +1987,10 @@ public class RythmEngine implements IEventDispatcher {
 
         // clear all template tags which is managed by TemplateClassManager
         List<String> templateTags = new ArrayList<String>();
-        for (String name : _templates.keySet()) {
-            ITag tag = _templates.get(name);
+        for (Map.Entry<String, ITemplate> entry : _templates.entrySet()) {
+            ITag tag = entry.getValue();
             if (!(tag instanceof JavaTagBase)) {
-                templateTags.add(name);
+                templateTags.add(entry.getKey());
             }
         }
         for (String name : templateTags) {

--- a/src/main/java/org/rythmengine/internal/AutoToStringCodeBuilder.java
+++ b/src/main/java/org/rythmengine/internal/AutoToStringCodeBuilder.java
@@ -67,10 +67,10 @@ public class AutoToStringCodeBuilder extends CodeBuilder {
             p2tn("__logTime = true;");
         }
         p2t("__style = ").p(meta.style.toCode()).p(";").pn();
-        for (String argName : renderArgs.keySet()) {
-            RenderArgDeclaration arg = renderArgs.get(argName);
-            p2t("if (").p(argName).p(" == null) {");
-            p(argName).p("=(").p(arg.objectType()).p(")__get(\"").p(argName).p("\");}\n");
+        for (Map.Entry<String, RenderArgDeclaration> entry : renderArgs.entrySet()) {
+            RenderArgDeclaration arg = entry.getValue();
+            p2t("if (").p(entry.getKey()).p(" == null) {");
+            p(entry.getKey()).p("=(").p(arg.objectType()).p(")__get(\"").p(entry.getKey()).p("\");}\n");
         }
         ptn("}");
     }

--- a/src/main/java/org/rythmengine/internal/CodeBuilder.java
+++ b/src/main/java/org/rythmengine/internal/CodeBuilder.java
@@ -971,9 +971,9 @@ public class CodeBuilder extends TextBuilder {
         pn();
         addInferencedRenderArgs();
         // -- output private members
-        for (String argName : renderArgs.keySet()) {
-            RenderArgDeclaration arg = renderArgs.get(argName);
-            pt("protected ").p(arg.type).p(" ").p(argName);
+        for (Map.Entry<String, RenderArgDeclaration> entry : renderArgs.entrySet()) {
+            RenderArgDeclaration arg = entry.getValue();
+            pt("protected ").p(arg.type).p(" ").p(entry.getKey());
             if (null != arg.defVal) {
                 p("=").p(arg.defVal).p(";");
             } else {
@@ -1010,12 +1010,12 @@ public class CodeBuilder extends TextBuilder {
         pn();
         ptn("protected java.util.Map<java.lang.String, java.lang.Class> __renderArgTypeMap() {");
         p2tn("java.util.Map<java.lang.String, java.lang.Class> __m = new java.util.HashMap<String, Class>();");
-        for (String argName : renderArgs.keySet()) {
-            RenderArgDeclaration arg = renderArgs.get(argName);
+        for (Map.Entry<String, RenderArgDeclaration> entry : renderArgs.entrySet()) {
+            RenderArgDeclaration arg = entry.getValue();
             String argType = arg.type;
             boolean isGeneric = isGeneric(argType);
             if (isGeneric) {
-                p2t("__m.put(\"").p(argName).p("\", ").p(toNonGeneric(argType)).pn(".class);");
+                p2t("__m.put(\"").p(entry.getKey()).p("\", ").p(toNonGeneric(argType)).pn(".class);");
                 Regex regex = new Regex(".*((?@<>))");
                 regex.search(argType);
                 String s = regex.stringMatched(1);
@@ -1029,7 +1029,7 @@ public class CodeBuilder extends TextBuilder {
                         if ("?".equals(type)) {
                             type = "Object";
                         }
-                        p2t("__m.put(\"").p(argName).p("__").p(i).p("\", ").p(type).pn(".class);");
+                        p2t("__m.put(\"").p(entry.getKey()).p("__").p(i).p("\", ").p(type).pn(".class);");
                     }
                 }
             } else {
@@ -1037,7 +1037,7 @@ public class CodeBuilder extends TextBuilder {
                 if ("?".equals(type)) {
                     type = "Object";
                 }
-                p2t("__m.put(\"").p(argName).p("\", ").p(type).pn(".class);");
+                p2t("__m.put(\"").p(entry.getKey()).p("\", ").p(type).pn(".class);");
 //                int lvl = 0;
 //                if (isArray(type)) {
 //                    int pos = type.lastIndexOf("[");
@@ -1056,9 +1056,9 @@ public class CodeBuilder extends TextBuilder {
         p2tn("if (null == __args) throw new NullPointerException();\n\t\tif (__args.isEmpty()) return this;");
         p2tn("super.__setRenderArgs(__args);");
         first = true;
-        for (String argName : renderArgs.keySet()) {
-            RenderArgDeclaration arg = renderArgs.get(argName);
-            p2t("if (__args.containsKey(\"").p(argName).p("\")) this.").p(argName).p(" = __get(__args,\"").p(argName).p("\",").p(arg.objectType()).pn(".class);");
+        for (Map.Entry<String, RenderArgDeclaration> entry : renderArgs.entrySet()) {
+            RenderArgDeclaration arg = entry.getValue();
+            p2t("if (__args.containsKey(\"").p(entry.getKey()).p("\")) this.").p(entry.getKey()).p(" = __get(__args,\"").p(entry.getKey()).p("\",").p(arg.objectType()).pn(".class);");
         }
         p2tn("return this;");
 //        for (String argName : renderArgs.keySet()) {
@@ -1165,10 +1165,10 @@ public class CodeBuilder extends TextBuilder {
         if (logTime) {
             p2tn("__logTime = true;");
         }
-        for (String argName : renderArgs.keySet()) {
-            RenderArgDeclaration arg = renderArgs.get(argName);
-            p2t("if (__isDefVal(").p(argName).p(")) {");
-            p(argName).p(" = __get(\"").p(argName).p("\",").p(arg.objectType()).p(".class) ;}\n");
+        for (Map.Entry<String, RenderArgDeclaration> entry : renderArgs.entrySet()) {
+            RenderArgDeclaration arg = entry.getValue();
+            p2t("if (__isDefVal(").p(entry.getKey()).p(")) {");
+            p(entry.getKey()).p(" = __get(\"").p(entry.getKey()).p("\",").p(arg.objectType()).p(".class) ;}\n");
         }
         ptn("}");
     }

--- a/src/main/java/org/rythmengine/internal/EventBus.java
+++ b/src/main/java/org/rythmengine/internal/EventBus.java
@@ -188,10 +188,10 @@ public class EventBus implements IEventDispatcher {
                 }
                 // add common render args
                 Map<String, ?> defArgs = ce.getRenderArgDescriptions();
-                for (String name : defArgs.keySet()) {
-                    Object o = defArgs.get(name);
+                for (Map.Entry<String, ?> entry : defArgs.entrySet()) {
+                    Object o = entry.getValue();
                     String type = (o instanceof Class<?>) ? ((Class<?>) o).getName() : o.toString();
-                    cb.addRenderArgs(-1, type, name);
+                    cb.addRenderArgs(-1, type, entry.getKey());
                 }
                 // add common imports
                 for (String s : ce.imports()) {

--- a/src/main/java/org/rythmengine/internal/compiler/ParamTypeInferencer.java
+++ b/src/main/java/org/rythmengine/internal/compiler/ParamTypeInferencer.java
@@ -126,11 +126,11 @@ public class ParamTypeInferencer {
         long id = 0;
         if (args.length == 1 && args[0] instanceof Map) {
             Map<String, Object> params = (Map) args[0];
-            for (String name : params.keySet()) {
-                Object val = params.get(name);
+            for (Map.Entry<String, Object> entry : params.entrySet()) {
+                Object val = entry.getValue();
                 String typeName = getTypeName(val);
-                tMap.put(name, typeName);
-                id += typeName.hashCode() * name.hashCode();
+                tMap.put(entry.getKey(), typeName);
+                id += typeName.hashCode() * entry.getKey().hashCode();
             }
         } else {
             // suppose template variable is denoted with @1, @2 ...

--- a/src/main/java/org/rythmengine/internal/compiler/TemplateClass.java
+++ b/src/main/java/org/rythmengine/internal/compiler/TemplateClass.java
@@ -165,10 +165,10 @@ public class TemplateClass {
         if (includeTagTypes.isEmpty()) return "";
         StringBuilder sb = new StringBuilder();
         boolean empty = true;
-        for (String tagName : includeTagTypes.keySet()) {
+        for (Map.Entry<String, String> entry : includeTagTypes.entrySet()) {
             if (!empty) sb.append(";");
             else empty = false;
-            sb.append(tagName).append(":").append(includeTagTypes.get(tagName));
+            sb.append(entry.getKey()).append(":").append(entry.getValue());
         }
         return sb.toString();
     }

--- a/src/main/java/org/rythmengine/internal/compiler/TemplateClassManager.java
+++ b/src/main/java/org/rythmengine/internal/compiler/TemplateClassManager.java
@@ -125,9 +125,9 @@ public class TemplateClassManager {
 
     List<TemplateClass> getEmbeddedClasses(String name) {
         List<TemplateClass> l = new ArrayList<TemplateClass>();
-        for (String cn : clsNameIdx.keySet()) {
-            if (cn.startsWith(name + "$")) {
-                l.add(clsNameIdx.get(cn));
+        for (Map.Entry<String, TemplateClass> entry : clsNameIdx.entrySet()) {
+            if (entry.getKey().startsWith(name + "$")) {
+                l.add(entry.getValue());
             }
         }
         return l;

--- a/src/main/java/org/rythmengine/internal/dialect/DialectBase.java
+++ b/src/main/java/org/rythmengine/internal/dialect/DialectBase.java
@@ -73,9 +73,9 @@ public abstract class DialectBase implements IDialect {
     public IParser createBuildInParser(String keyword, IContext context) {
         KeywordParserFactory f = keywords.get(keyword.toLowerCase());
         if (null == f) {
-            for (String r : keywords2.keySet()) {
-                if (keyword.matches(r)) {
-                    f = keywords2.get(r);
+            for (Map.Entry<String, KeywordParserFactory> entry : keywords2.entrySet()) {
+                if (keyword.matches(entry.getKey())) {
+                    f = entry.getValue();
                     break;
                 }
             }

--- a/src/main/java/org/rythmengine/template/TemplateBase.java
+++ b/src/main/java/org/rythmengine/template/TemplateBase.java
@@ -478,14 +478,14 @@ public abstract class TemplateBase extends TemplateBuilder implements ITemplate 
             tmpl.__caller = (TextBuilder) caller;
             Map<String, Object> callerRenderArgs = new HashMap<String, Object>(((TemplateBase) caller).__renderArgs);
             Map<String, Class> types = tmpl.__renderArgTypeMap();
-            for (String s : callerRenderArgs.keySet()) {
-                if (tmpl.__renderArgs.containsKey(s)) continue;
-                Object o = callerRenderArgs.get(s);
+            for (Map.Entry<String, Object> entry : callerRenderArgs.entrySet()) {
+                if (tmpl.__renderArgs.containsKey(entry.getKey())) continue;
+                Object o = entry.getValue();
                 if (null == o || __isDefVal(o)) continue;
-                Class<?> c = types.get(s);
+                Class<?> c = types.get(entry.getKey());
 
                 if (null == c || c.isAssignableFrom(o.getClass())) {
-                    tmpl.__setRenderArg(s, o);
+                    tmpl.__setRenderArg(entry.getKey(), o);
                 }
             }
         }
@@ -898,20 +898,20 @@ public abstract class TemplateBase extends TemplateBuilder implements ITemplate 
 
     private void setJSONObject(Map<String, Object> jsonObject) {
         Map<String, Class> types = __renderArgTypeMap();
-        for (String nm : jsonObject.keySet()) {
-            if (types.containsKey(nm)) {
-                Class c = types.get(nm);
-                Object o = jsonObject.get(nm);
+        for (Map.Entry<String, Object> entry : jsonObject.entrySet()) {
+            if (types.containsKey(entry.getKey())) {
+                Class c = types.get(entry.getKey());
+                Object o = entry.getValue();
                 Object p;
                 if (o instanceof List) {
                     Map<String, Class> typeMap = __renderArgTypeMap();
                     //String vn = nm;
-                    Class c0 = typeMap.get(nm + "__0");
+                    Class c0 = typeMap.get(entry.getKey() + "__0");
                     boolean isArray = false;
                     if (null == c0) {
                         // an array type
                         isArray = true;
-                        c0 = typeMap.get(nm);
+                        c0 = typeMap.get(entry.getKey());
                     }
                     if (isArray) {
                         JSONArray l = (JSONArray) o;
@@ -937,7 +937,7 @@ public abstract class TemplateBase extends TemplateBuilder implements ITemplate 
                         p = JSON.parseObject(s, c);
                     }
                 }
-                __setRenderArg(nm, p);
+                __setRenderArg(entry.getKey(), p);
             }
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - “ "entrySet()" should be iterated when both the key and value are needed ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
Ayman Abdelghany.