### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/org/rythmengine/internal/compiler/TemplateClassLoader.java
+++ b/src/main/java/org/rythmengine/internal/compiler/TemplateClassLoader.java
@@ -85,7 +85,7 @@ public class TemplateClassLoader extends ClassLoader {
         private final Map<File, FileWithClassDefs> classDefsInFileCache = new HashMap<File, FileWithClassDefs>();
 
         public synchronized int computePathHash(File... paths) {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             for (File file : paths) {
                 scan(buf, file);
             }
@@ -94,7 +94,7 @@ public class TemplateClassLoader extends ClassLoader {
             return buf.toString().hashCode();
         }
 
-        private void scan(StringBuffer buf, File current) {
+        private void scan(StringBuilder buf, File current) {
             if (!current.isDirectory()) {
                 if (current.getName().endsWith(".java")) {
                     buf.append(getClassDefsForFile(current));

--- a/src/main/java/org/rythmengine/utils/S.java
+++ b/src/main/java/org/rythmengine/utils/S.java
@@ -1533,7 +1533,7 @@ public class S {
 
         final int max = chars.length;
         Random r = new Random();
-        StringBuffer sb = new StringBuffer(len);
+        StringBuilder sb = new StringBuilder(len);
         while(len-- > 0) {
             int i = r.nextInt(max);
             sb.append(chars[i]);

--- a/src/main/java/org/rythmengine/utils/Time.java
+++ b/src/main/java/org/rythmengine/utils/Time.java
@@ -850,7 +850,7 @@ public class Time {
         }
 
         public String getExpressionSummary() {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
 
             buf.append("seconds: ");
             buf.append(getExpressionSetSummary(seconds));
@@ -898,7 +898,7 @@ public class Time {
                 return "*";
             }
 
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
 
             Iterator<Integer> itr = set.iterator();
             boolean first = true;
@@ -924,7 +924,7 @@ public class Time {
                 return "*";
             }
 
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
 
             Iterator<Integer> itr = list.iterator();
             boolean first = true;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “ Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.