### PR TITLE
 Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET

### DIFF
--- a/src/main/java/org/rythmengine/RythmEngine.java
+++ b/src/main/java/org/rythmengine/RythmEngine.java
@@ -1394,7 +1394,7 @@ public class RythmEngine implements IEventDispatcher {
 //        } catch (ScriptException e) {
 //            throw new RuntimeException(e);
 //        }
-        return eval(script, Collections.EMPTY_MAP);
+        return eval(script, Collections.<String, Object>emptyMap());
     }
 
     private Map<String, Serializable> mvels = new HashMap<String, Serializable>();

--- a/src/main/java/org/rythmengine/conf/RythmConfiguration.java
+++ b/src/main/java/org/rythmengine/conf/RythmConfiguration.java
@@ -600,7 +600,7 @@ public class RythmConfiguration {
         return _hasGlobalInclude;
     }
 
-    public static final RythmConfiguration EMPTY_CONF = new RythmConfiguration(Collections.EMPTY_MAP, null);
+    public static final RythmConfiguration EMPTY_CONF = new RythmConfiguration(Collections.<String, Object>emptyMap(), null);
 
     /**
      * Return <tt>RythmConfiguration</tt> instance of current RythmEngine, or

--- a/src/main/java/org/rythmengine/conf/RythmConfigurationKey.java
+++ b/src/main/java/org/rythmengine/conf/RythmConfigurationKey.java
@@ -842,7 +842,7 @@ public enum RythmConfigurationKey {
 
     public static <T> List<T> getImplList(String key, Map<String, ?> configuration, Class<T> c) {
         final Object v = getValFromAliases(configuration, key, "impls", null);
-        if (null == v) return Collections.EMPTY_LIST;
+        if (null == v) return Collections.emptyList();
         final boolean needClass = (Class.class.isAssignableFrom(c));
         final List<T> l = new ArrayList<T>();
         final Class vc = v.getClass();

--- a/src/main/java/org/rythmengine/extension/ICodeType.java
+++ b/src/main/java/org/rythmengine/extension/ICodeType.java
@@ -246,7 +246,7 @@ public interface ICodeType {
 
         @Override
         public Set<ICodeType> allowedExternalTypes() {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
 
         @Override

--- a/src/test/java/org/rythmengine/essential/ArgsParserTest.java
+++ b/src/test/java/org/rythmengine/essential/ArgsParserTest.java
@@ -46,7 +46,7 @@ public class ArgsParserTest extends TestBase {
     @Test
     public void testFullFormat() {
         t = "@args() {Map<String, String> m\n, List<Integer> l,}@(m instanceof Map),@(l instanceof List)";
-        s = r(t, Collections.EMPTY_MAP, Collections.EMPTY_LIST);
+        s = r(t, Collections.emptyMap(), Collections.emptyList());
         eq("true,true");
     }
     

--- a/src/test/java/org/rythmengine/essential/ForParserTest.java
+++ b/src/test/java/org/rythmengine/essential/ForParserTest.java
@@ -335,14 +335,14 @@ public class ForParserTest extends TestBase {
     @Test
     public void test2() {
         t = "@args Set<Map<String,String>> mset;@for(Map<String, String> m: mset){123}";
-        s = r(t, Collections.EMPTY_SET);
+        s = r(t, Collections.emptySet());
         eq("");
     }
     
     @Test
     public void test3() {
         t = "@args List items\n     @for(Object item: items) {\n@{}}";
-        s = r(t, Collections.EMPTY_LIST);
+        s = r(t, Collections.emptyList());
         eq("");
     }
     
@@ -359,7 +359,7 @@ public class ForParserTest extends TestBase {
     @Test
     public void test5() {
         t = "@for(items){@__sep}";
-        s = r(t, from(p("items", Collections.EMPTY_LIST)));
+        s = r(t, from(p("items", Collections.emptyList())));
         eq("");
     }
 

--- a/src/test/java/org/rythmengine/essential/IfParserTest.java
+++ b/src/test/java/org/rythmengine/essential/IfParserTest.java
@@ -171,9 +171,9 @@ public class IfParserTest extends TestBase {
         no("NO");
         yes("yes");
         no("  ");
-        no(Collections.EMPTY_LIST);
-        no(Collections.EMPTY_MAP);
-        no(Collections.EMPTY_SET);
+        no(Collections.emptyList());
+        no(Collections.emptyMap());
+        no(Collections.emptySet());
         yes(Arrays.asList("1,2".split(",")));
         yes(1);
         no(0L);

--- a/src/test/java/org/rythmengine/issue/GhIssueTest.java
+++ b/src/test/java/org/rythmengine/issue/GhIssueTest.java
@@ -474,7 +474,7 @@ public class GhIssueTest extends TestBase {
         ISourceCodeEnhancer se = new ISourceCodeEnhancer() {
             @Override
             public List<String> imports() {
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
 
             @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1596 - “Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1596
Please let me know if you have any questions.
Ayman Abdelghany.